### PR TITLE
feat(mits): add date range support for list_mits tool

### DIFF
--- a/drizzle/0001_add_mits_date_index.sql
+++ b/drizzle/0001_add_mits_date_index.sql
@@ -1,0 +1,2 @@
+-- Add composite index on date and order for better query performance
+CREATE INDEX idx_mits_date_order ON mits(date DESC, "order" ASC);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,95 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b918f602-0786-4107-b060-e019b7779c24",
+  "prevId": "b918f602-0786-4107-b060-e019b7779c23",
+  "tables": {
+    "mits": {
+      "name": "mits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_mits_date_order": {
+          "name": "idx_mits_date_order",
+          "columns": [
+            {
+              "name": "date",
+              "isExpression": false
+            },
+            {
+              "name": "order",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1750922159253,
       "tag": "0000_charming_kronos",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1750922159254,
+      "tag": "0001_add_mits_date_index",
+      "breakpoints": true
     }
   ]
 }

--- a/src/services/mitService.test.ts
+++ b/src/services/mitService.test.ts
@@ -238,7 +238,7 @@ describe('mitService', () => {
       mockLimit.mockResolvedValue([]);
     });
 
-    it('should return today\'s MITs when no parameters provided', async () => {
+    it("should return today's MITs when no parameters provided", async () => {
       const mockMits: Mit[] = [
         {
           id: '1',

--- a/src/services/mitService.ts
+++ b/src/services/mitService.ts
@@ -105,14 +105,6 @@ export const mitService = {
       .limit(limit);
   },
 
-  findByDate: async (date: string): Promise<Mit[]> => {
-    return db
-      .select()
-      .from(mits)
-      .where(eq(mits.date, date))
-      .orderBy(mits.order);
-  },
-
   update: async (
     id: string,
     data: Partial<Omit<NewMit, 'id'>>,

--- a/src/services/mitService.ts
+++ b/src/services/mitService.ts
@@ -59,17 +59,19 @@ export const mitService = {
     return db.select().from(mits).orderBy(mits.order);
   },
 
-  find: async (options: {
-    startDate?: string;
-    endDate?: string;
-    completed?: boolean;
-    limit?: number;
-  } = {}): Promise<Mit[]> => {
+  find: async (
+    options: {
+      startDate?: string;
+      endDate?: string;
+      completed?: boolean;
+      limit?: number;
+    } = {},
+  ): Promise<Mit[]> => {
     const { startDate, endDate, completed, limit = 100 } = options;
 
     // Build where conditions
     const conditions = [];
-    
+
     // If no dates provided, default to today
     if (!startDate && !endDate) {
       conditions.push(eq(mits.date, getLocalDateString()));
@@ -86,18 +88,17 @@ export const mitService = {
         conditions.push(lte(mits.date, endDate));
       }
     }
-    
+
     // Add completed filter if specified
     if (completed !== undefined) {
       conditions.push(eq(mits.completed, completed));
     }
-    
+
     // Build query with all conditions
     const baseQuery = db.select().from(mits);
-    const queryWithConditions = conditions.length > 0 
-      ? baseQuery.where(and(...conditions))
-      : baseQuery;
-    
+    const queryWithConditions =
+      conditions.length > 0 ? baseQuery.where(and(...conditions)) : baseQuery;
+
     // Apply ordering and limit
     return queryWithConditions
       .orderBy(desc(mits.date), asc(mits.order))

--- a/src/tools/mits.ts
+++ b/src/tools/mits.ts
@@ -9,7 +9,7 @@ export function registerMitsTool(server: McpServer) {
     'list_mits',
     {
       title: 'List MITs with flexible date range and filters',
-      description: 'List MITs for today, a date range, or with filters',
+      description: 'List MITs (Most Important Tasks). Returns today\'s MITs by default. Use startDate/endDate for date ranges, completed to filter by status, limit to control results (default 100). Results ordered by date DESC, order ASC.',
       inputSchema: z.object({
         startDate: z
           .string()
@@ -52,7 +52,7 @@ export function registerMitsTool(server: McpServer) {
     'create_mit',
     {
       title: 'Create a new MIT',
-      description: 'Create a new MIT',
+      description: 'Create a new MIT (Most Important Task). Required: description. Optional: order (auto-calculated if omitted), date (defaults to today, must be today or future).',
       inputSchema: z.object({
         description: z.string().min(1, 'Description is required'),
         order: z.number().int().min(1, 'Order must be at least 1').optional(),
@@ -88,7 +88,7 @@ export function registerMitsTool(server: McpServer) {
     'update_mit',
     {
       title: 'Update a MIT',
-      description: 'Update a MIT',
+      description: 'Update an existing MIT by ID. Can modify description, completed status, order, or date.',
       inputSchema: z.object({
         id: z.string().uuid('Invalid MIT ID format'),
         description: z.string().min(1).optional(),
@@ -130,7 +130,7 @@ export function registerMitsTool(server: McpServer) {
     'delete_mit',
     {
       title: 'Delete a MIT',
-      description: 'Delete a MIT',
+      description: 'Delete a MIT by its ID. Returns the deleted MIT details.',
       inputSchema: z.object({
         id: z.string().uuid('Invalid MIT ID format'),
       }).shape,

--- a/src/tools/mits.ts
+++ b/src/tools/mits.ts
@@ -8,20 +8,36 @@ export function registerMitsTool(server: McpServer) {
   server.registerTool(
     'list_mits',
     {
-      title: 'List MITs for today or a specific date',
-      description: 'List MITs for today or a specific date',
+      title: 'List MITs with flexible date range and filters',
+      description: 'List MITs for today, a date range, or with filters',
       inputSchema: z.object({
-        date: z
+        startDate: z
           .string()
           .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
           .optional(),
+        endDate: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+          .optional(),
+        completed: z
+          .boolean()
+          .optional(),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(10000)
+          .optional(),
       }).shape,
     },
-    async ({ date }) => {
+    async ({ startDate, endDate, completed, limit }) => {
       try {
-        // If no date provided, use today's date
-        const targetDate = date || getLocalDateString();
-        const mits = await mitService.findByDate(targetDate);
+        const mits = await mitService.find({
+          startDate,
+          endDate,
+          completed,
+          limit,
+        });
         return {
           content: [{ type: 'text', text: JSON.stringify(mits, null, 2) }],
         };

--- a/src/tools/mits.ts
+++ b/src/tools/mits.ts
@@ -9,7 +9,8 @@ export function registerMitsTool(server: McpServer) {
     'list_mits',
     {
       title: 'List MITs with flexible date range and filters',
-      description: 'List MITs (Most Important Tasks). Returns today\'s MITs by default. Use startDate/endDate for date ranges, completed to filter by status, limit to control results (default 100). Results ordered by date DESC, order ASC.',
+      description:
+        "List MITs (Most Important Tasks). Returns today's MITs by default. Use startDate/endDate for date ranges, completed to filter by status, limit to control results (default 100). Results ordered by date DESC, order ASC.",
       inputSchema: z.object({
         startDate: z
           .string()
@@ -52,7 +53,8 @@ export function registerMitsTool(server: McpServer) {
     'create_mit',
     {
       title: 'Create a new MIT',
-      description: 'Create a new MIT (Most Important Task). Required: description. Optional: order (auto-calculated if omitted), date (defaults to today, must be today or future).',
+      description:
+        'Create a new MIT (Most Important Task). Required: description. Optional: order (auto-calculated if omitted), date (defaults to today, must be today or future).',
       inputSchema: z.object({
         description: z.string().min(1, 'Description is required'),
         order: z.number().int().min(1, 'Order must be at least 1').optional(),
@@ -88,7 +90,8 @@ export function registerMitsTool(server: McpServer) {
     'update_mit',
     {
       title: 'Update a MIT',
-      description: 'Update an existing MIT by ID. Can modify description, completed status, order, or date.',
+      description:
+        'Update an existing MIT by ID. Can modify description, completed status, order, or date.',
       inputSchema: z.object({
         id: z.string().uuid('Invalid MIT ID format'),
         description: z.string().min(1).optional(),

--- a/src/tools/mits.ts
+++ b/src/tools/mits.ts
@@ -19,15 +19,8 @@ export function registerMitsTool(server: McpServer) {
           .string()
           .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
           .optional(),
-        completed: z
-          .boolean()
-          .optional(),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(10000)
-          .optional(),
+        completed: z.boolean().optional(),
+        limit: z.number().int().min(1).max(10000).optional(),
       }).shape,
     },
     async ({ startDate, endDate, completed, limit }) => {


### PR DESCRIPTION
## Summary
- Replace single date parameter with flexible date range support
- Add completed status filter and configurable limit parameter
- Improve query performance with database index
- Remove redundant `findByDate` method

## Changes
- **BREAKING CHANGE**: `list_mits` now uses `startDate`/`endDate` instead of single `date` parameter
- Added new `find` method in `mitService` with support for:
  - Date ranges (startDate, endDate)
  - Completed status filtering
  - Configurable limit (default: 100)
- Added composite database index on `(date, order)` for optimal query performance
- Updated tests to cover all new functionality
- Removed redundant `findByDate` method (can use `find({ startDate: date, endDate: date })` instead)

## Usage Examples
```javascript
// Today's MITs (default behavior)
list_mits()

// Past week
list_mits({ startDate: "2025-01-01", endDate: "2025-01-07" })

// All future MITs from a date
list_mits({ startDate: "2025-01-08", limit: 500 })

// Only incomplete MITs
list_mits({ completed: false })
```

## Test Plan
- [x] All existing tests pass
- [x] Added new tests for date range queries
- [x] Added tests for completed status filtering
- [x] Added tests for custom limit
- [x] TypeScript compilation successful
- [x] Linting passes
- [x] Database migration applied successfully